### PR TITLE
ZooKeeper connection pooling

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -85,6 +85,8 @@ jobs:
         image: zookeeper:${{ matrix.zookeeper }}
         ports:
           - 2181:2181
+        env:
+          ZOO_MAX_CLIENT_CNXNS: 200
 
     steps:
 

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -85,8 +85,6 @@ jobs:
         image: zookeeper:${{ matrix.zookeeper }}
         ports:
           - 2181:2181
-        env:
-          ZOO_MAX_CLIENT_CNXNS: 200
 
     steps:
 

--- a/Makefile
+++ b/Makefile
@@ -47,4 +47,4 @@ local.zk.restart:
 local.test:
 	ZOOKEEPER_SERVERS=$(LOCAL_ZOOKEEPER_SERVERS) TF_ACC=1 make test
 
-.PHONY: build install lint generate fmt deps.update test testacc local.zk.up local.zk.down local.zk.restart local.testacc
+.PHONY: build install lint generate fmt deps.update test local.zk.up local.zk.down local.zk.restart local.test

--- a/README.md
+++ b/README.md
@@ -30,9 +30,11 @@ version it implements, and Terraform:
 
 ### CI Testing
 
-This provider is tested against Terraform versions from `0.12` to `1.9`.
+The provider test suite is run against all Terraform versions from `0.12` to `1.9`,
+as well as all ZooKeeper versions from `3.5` to `3.9`. 
+
 See the [Build and Test](https://github.com/tfzk/terraform-provider-zookeeper/blob/main/.github/workflows/build-test.yml)
-workflow.
+workflow for details.
 
 ## Provider features
 
@@ -65,7 +67,7 @@ To run acceptance tests, you will need a ZooKeeper Ensemble running:
 ```shell
 $ make local.zk.up
 
-$ make local.testacc
+$ make local.test
 
 # ... do your development / fixing ...
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -61,8 +61,8 @@ provider "zookeeper" {
 ### Optional
 
 - `password` (String, Sensitive) Password for digest authentication. Can be set via `ZOOKEEPER_PASSWORD` environment variable.
-- `servers` (String) A comma separated list of 'host:port' pairs, pointing at ZooKeeper Server(s).
-- `session_timeout` (Number) How many seconds a session is considered valid after losing connectivity. More information about ZooKeeper sessions can be found [here](#zookeeper-sessions).
+- `servers` (String) A comma separated list of 'host:port' pairs, pointing at ZooKeeper Server(s). Can be set via `ZOOKEEPER_SERVERS` environment variable.
+- `session_timeout` (Number) How many seconds a session is considered valid after losing connectivity. More information about ZooKeeper sessions can be found [here](#zookeeper-sessions). Can be set via `ZOOKEEPER_SESSION` environment variable.
 - `username` (String, Sensitive) Username for digest authentication. Can be set via `ZOOKEEPER_USERNAME` environment variable.
 
 ## Important aspects about ZooKeeper and this provider

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -66,8 +66,12 @@ const (
 	// Client timeout session, in case EnvZooKeeperSessionSec is not set.
 	DefaultZooKeeperSessionSec = 30
 
-	// Environment variables to provide digest auth credentials.
+	// EnvZooKeeperUsername environment variable providing the username part of a digest auth credentials.
+	// This is used by NewClientFromEnv.
 	EnvZooKeeperUsername = "ZOOKEEPER_USERNAME"
+
+	// EnvZooKeeperPassword environment variable providing the password part of a digest auth credentials.
+	// This is used by NewClientFromEnv.
 	EnvZooKeeperPassword = "ZOOKEEPER_PASSWORD"
 )
 

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -3,10 +3,8 @@ package client
 import (
 	"errors"
 	"fmt"
-	"os"
 	"path/filepath"
 	"sort"
-	"strconv"
 	"strings"
 	"time"
 
@@ -83,6 +81,7 @@ func NewClient(servers string, sessionTimeoutSec int, username string, password 
 	if err != nil {
 		return nil, fmt.Errorf("unable to connect to ZooKeeper: %w", err)
 	}
+	fmt.Printf("[DEBUG] Connected to ZooKeeper servers %s\n", serversSplit)
 
 	if (username == "") != (password == "") {
 		return nil, fmt.Errorf("both username and password must be specified together")
@@ -100,31 +99,6 @@ func NewClient(servers string, sessionTimeoutSec int, username string, password 
 	return &Client{
 		zkConn: conn,
 	}, nil
-}
-
-// NewClientFromEnv constructs a new Client instance from environment variables.
-//
-// The only mandatory environment variable is EnvZooKeeperServer.
-func NewClientFromEnv() (*Client, error) {
-	zkServers, ok := os.LookupEnv(EnvZooKeeperServer)
-	if !ok {
-		return nil, fmt.Errorf("missing environment variable: %s", EnvZooKeeperServer)
-	}
-
-	zkSession, ok := os.LookupEnv(EnvZooKeeperSessionSec)
-	if !ok {
-		zkSession = strconv.FormatInt(DefaultZooKeeperSessionSec, 10)
-	}
-
-	zkSessionInt, err := strconv.Atoi(zkSession)
-	if err != nil {
-		return nil, fmt.Errorf("failed to convert '%s' to integer: %w", zkSession, err)
-	}
-
-	zkUsername, _ := os.LookupEnv(EnvZooKeeperUsername)
-	zkPassword, _ := os.LookupEnv(EnvZooKeeperPassword)
-
-	return NewClient(zkServers, zkSessionInt, zkUsername, zkPassword)
 }
 
 // Create a ZNode at the given path.
@@ -258,11 +232,6 @@ func (c *Client) Update(path string, data []byte, acl []zk.ACL) (*ZNode, error) 
 	}
 
 	return c.Read(path)
-}
-
-// Close the connection.
-func (c *Client) Close() {
-	c.zkConn.Close()
 }
 
 // Delete the given ZNode.

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -129,12 +129,6 @@ func NewClientFromEnv() (*Client, error) {
 	return NewClient(zkServers, zkSessionInt, zkUsername, zkPassword)
 }
 
-// Close the Client underlying connection.
-func (c *Client) Close() {
-	fmt.Println("[DEBUG] Closing underlying ZooKeeper connection")
-	c.zkConn.Close()
-}
-
 // Create a ZNode at the given path.
 //
 // Note that any necessary ZNode parents will be created if absent.
@@ -266,6 +260,12 @@ func (c *Client) Update(path string, data []byte, acl []zk.ACL) (*ZNode, error) 
 	}
 
 	return c.Read(path)
+}
+
+// Close the Client underlying connection.
+func (c *Client) Close() {
+	fmt.Println("[DEBUG] Closing underlying ZooKeeper connection")
+	c.zkConn.Close()
 }
 
 // Delete the given ZNode.

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -11,7 +11,7 @@ import (
 func initTest(t *testing.T) (*client.Client, *testifyAssert.Assertions) {
 	assert := testifyAssert.New(t)
 
-	client, err := client.NewClientFromEnv()
+	client, err := client.DefaultPool().GetClientFromEnv()
 	assert.NoError(err)
 
 	return client, assert
@@ -134,7 +134,7 @@ func TestFailureWhenReadingZNodeWithIncorrectAuth(t *testing.T) {
 	// Create client authenticated as bar user
 	t.Setenv(client.EnvZooKeeperUsername, "bar")
 	t.Setenv(client.EnvZooKeeperPassword, "password")
-	barClient, err := client.NewClientFromEnv()
+	barClient, err := client.DefaultPool().GetClientFromEnv()
 	assert.NoError(err)
 
 	// The node should be inaccessible by bar user

--- a/internal/client/pool.go
+++ b/internal/client/pool.go
@@ -2,19 +2,17 @@ package client
 
 import (
 	"fmt"
-	"os"
-	"strconv"
 	"sync"
 )
 
-// Pool wraps a collection of Client.
+// Pool contains a pool of Client.
 // Each client is associated to a unique set of construction parameters.
 type Pool struct {
 	mu   sync.Mutex
 	pool map[string]*Client
 }
 
-func newPool() *Pool {
+func NewPool() *Pool {
 	return &Pool{
 		pool: make(map[string]*Client),
 	}
@@ -26,50 +24,15 @@ func (p *Pool) GetClient(servers string, sessionTimeoutSec int, username string,
 	defer p.mu.Unlock()
 
 	clientKey := fmt.Sprintf("%s::%d::%s::%s", servers, sessionTimeoutSec, username, password)
+
+	// Return client if already present for the same key
 	if client, found := p.pool[clientKey]; found {
 		return client, nil
 	}
 
+	// Create new client, and cache it for the given key
 	client, err := NewClient(servers, sessionTimeoutSec, username, password)
 	p.pool[clientKey] = client
 
 	return client, err
-}
-
-// GetClientFromEnv retrieves (or creates) a Client instance from environment variables.
-//
-// The only mandatory environment variable is EnvZooKeeperServer.
-func (p *Pool) GetClientFromEnv() (*Client, error) {
-	zkServers, ok := os.LookupEnv(EnvZooKeeperServer)
-	if !ok {
-		return nil, fmt.Errorf("missing environment variable: %s", EnvZooKeeperServer)
-	}
-
-	zkSession, ok := os.LookupEnv(EnvZooKeeperSessionSec)
-	if !ok {
-		zkSession = strconv.FormatInt(DefaultZooKeeperSessionSec, 10)
-	}
-
-	zkSessionInt, err := strconv.Atoi(zkSession)
-	if err != nil {
-		return nil, fmt.Errorf("failed to convert '%s' to integer: %w", zkSession, err)
-	}
-
-	zkUsername, _ := os.LookupEnv(EnvZooKeeperUsername)
-	zkPassword, _ := os.LookupEnv(EnvZooKeeperPassword)
-
-	return p.GetClient(zkServers, zkSessionInt, zkUsername, zkPassword)
-}
-
-//nolint:gochecknoglobals
-var defaultPool *Pool
-
-func init() {
-	defaultPool = newPool()
-}
-
-// DefaultPool returns a pointer to the default (and unique) instance of Pool.
-// This is essentially a singleton.
-func DefaultPool() *Pool {
-	return defaultPool
 }

--- a/internal/client/pool.go
+++ b/internal/client/pool.go
@@ -18,8 +18,9 @@ func NewPool() *Pool {
 	}
 }
 
-// GetClient retrieves (or creates) a Client.
-func (p *Pool) GetClient(servers string, sessionTimeoutSec int, username string, password string) (*Client, error) {
+// GetOrCreateClient retrieves (or creates) a Client.
+// A new client is created for each unique set of construction parameters.
+func (p *Pool) GetOrCreateClient(servers string, sessionTimeoutSec int, username string, password string) (*Client, error) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 

--- a/internal/client/pool.go
+++ b/internal/client/pool.go
@@ -1,0 +1,75 @@
+package client
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"sync"
+)
+
+// Pool wraps a collection of Client.
+// Each client is associated to a unique set of construction parameters.
+type Pool struct {
+	mu   sync.Mutex
+	pool map[string]*Client
+}
+
+func newPool() *Pool {
+	return &Pool{
+		pool: make(map[string]*Client),
+	}
+}
+
+// GetClient retrieves (or creates) a Client.
+func (p *Pool) GetClient(servers string, sessionTimeoutSec int, username string, password string) (*Client, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	clientKey := fmt.Sprintf("%s::%d::%s::%s", servers, sessionTimeoutSec, username, password)
+	if client, found := p.pool[clientKey]; found {
+		return client, nil
+	}
+
+	client, err := NewClient(servers, sessionTimeoutSec, username, password)
+	p.pool[clientKey] = client
+
+	return client, err
+}
+
+// GetClientFromEnv retrieves (or creates) a Client instance from environment variables.
+//
+// The only mandatory environment variable is EnvZooKeeperServer.
+func (p *Pool) GetClientFromEnv() (*Client, error) {
+	zkServers, ok := os.LookupEnv(EnvZooKeeperServer)
+	if !ok {
+		return nil, fmt.Errorf("missing environment variable: %s", EnvZooKeeperServer)
+	}
+
+	zkSession, ok := os.LookupEnv(EnvZooKeeperSessionSec)
+	if !ok {
+		zkSession = strconv.FormatInt(DefaultZooKeeperSessionSec, 10)
+	}
+
+	zkSessionInt, err := strconv.Atoi(zkSession)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert '%s' to integer: %w", zkSession, err)
+	}
+
+	zkUsername, _ := os.LookupEnv(EnvZooKeeperUsername)
+	zkPassword, _ := os.LookupEnv(EnvZooKeeperPassword)
+
+	return p.GetClient(zkServers, zkSessionInt, zkUsername, zkPassword)
+}
+
+//nolint:gochecknoglobals
+var defaultPool *Pool
+
+func init() {
+	defaultPool = newPool()
+}
+
+// DefaultPool returns a pointer to the default (and unique) instance of Pool.
+// This is essentially a singleton.
+func DefaultPool() *Pool {
+	return defaultPool
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
 	"github.com/tfzk/terraform-provider-zookeeper/internal/client"
 )
 
@@ -16,7 +17,8 @@ func New() (*schema.Provider, error) {
 				Optional:    true,
 				Sensitive:   false,
 				DefaultFunc: schema.EnvDefaultFunc(client.EnvZooKeeperServer, nil),
-				Description: "A comma separated list of 'host:port' pairs, pointing at ZooKeeper Server(s).",
+				Description: "A comma separated list of 'host:port' pairs, pointing at ZooKeeper Server(s). " +
+					"Can be set via `ZOOKEEPER_SERVERS` environment variable.",
 			},
 			"session_timeout": {
 				Type:        schema.TypeInt,
@@ -24,21 +26,24 @@ func New() (*schema.Provider, error) {
 				Sensitive:   false,
 				DefaultFunc: schema.EnvDefaultFunc(client.EnvZooKeeperSessionSec, client.DefaultZooKeeperSessionSec),
 				Description: "How many seconds a session is considered valid after losing connectivity. " +
-					"More information about ZooKeeper sessions can be found [here](#zookeeper-sessions).",
+					"More information about ZooKeeper sessions can be found [here](#zookeeper-sessions). " +
+					"Can be set via `ZOOKEEPER_SESSION` environment variable.",
 			},
 			"username": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Sensitive:   true,
 				DefaultFunc: schema.EnvDefaultFunc(client.EnvZooKeeperUsername, nil),
-				Description: "Username for digest authentication. Can be set via `ZOOKEEPER_USERNAME` environment variable.",
+				Description: "Username for digest authentication. " +
+					"Can be set via `ZOOKEEPER_USERNAME` environment variable.",
 			},
 			"password": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Sensitive:   true,
 				DefaultFunc: schema.EnvDefaultFunc(client.EnvZooKeeperPassword, nil),
-				Description: "Password for digest authentication. Can be set via `ZOOKEEPER_PASSWORD` environment variable.",
+				Description: "Password for digest authentication. " +
+					"Can be set via `ZOOKEEPER_PASSWORD` environment variable.",
 			},
 		},
 		ResourcesMap: map[string]*schema.Resource{

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -9,7 +9,8 @@ import (
 )
 
 func New() (*schema.Provider, error) {
-	// Hold a pool of Client, so a Client connecting to the same ZooKeeper can be shared between resources.
+	// Hold a Clients Pool, so connection to the same ZooKeeper can be shared between resources.
+	// The client is safe for concurrent usage.
 	clientPool := client.NewPool()
 
 	return &schema.Provider{
@@ -65,7 +66,7 @@ func New() (*schema.Provider, error) {
 			if servers != "" {
 				// NOTE: Client Pool above is in a closure here
 				// because we don't have a way to add fields to the Provider.
-				c, err := clientPool.GetClient(servers, sessionTimeout, username, password)
+				c, err := clientPool.GetOrCreateClient(servers, sessionTimeout, username, password)
 
 				if err != nil {
 					// Report inability to connect internal Client

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-
 	"github.com/tfzk/terraform-provider-zookeeper/internal/client"
 )
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -64,7 +64,7 @@ func configureProviderContext(_ context.Context, rscData *schema.ResourceData) (
 	password := rscData.Get("password").(string)
 
 	if servers != "" {
-		c, err := client.NewClient(servers, sessionTimeout, username, password)
+		c, err := client.DefaultPool().GetClient(servers, sessionTimeout, username, password)
 
 		if err != nil {
 			// Report inability to connect internal Client

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -37,13 +37,13 @@ func providerFactoriesMap() map[string]func() (*schema.Provider, error) {
 // checkPreconditions should be used with the field `PreCheck` of resource.TestCase.
 func checkPreconditions(t *testing.T) {
 	if v := os.Getenv(client.EnvZooKeeperServer); v == "" {
-		t.Fatalf("Environnment variable '%s' must be set for acceptance tests", client.EnvZooKeeperServer)
+		t.Fatalf("Environment variable '%s' must be set for acceptance tests", client.EnvZooKeeperServer)
 	}
 }
 
 // getTestZKClient can be used during test to procure a client.Client.
 func getTestZKClient() *client.Client {
-	zkClient, _ := client.NewClientFromEnv()
+	zkClient, _ := client.DefaultPool().GetClientFromEnv()
 	return zkClient
 }
 
@@ -62,6 +62,5 @@ func confirmAllZNodeDestroyed(s *terraform.State) error {
 		}
 	}
 
-	zkClient.Close()
 	return nil
 }

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -42,17 +42,18 @@ func checkPreconditions(t *testing.T) {
 }
 
 // getTestZKClient can be used during test to procure a client.Client.
-func getTestZKClient() *client.Client {
-	zkClient, _ := client.DefaultPool().GetClientFromEnv()
-	return zkClient
-}
 
 // confirmAllZNodeDestroyed should be used with the field `CheckDestroy` of resource.TestCase.
 func confirmAllZNodeDestroyed(s *terraform.State) error {
-	zkClient := getTestZKClient()
+	fmt.Println("[DEBUG] Confirming all ZNodes have been removed")
+	zkClient, err := client.NewClientFromEnv()
+	if err != nil {
+		return fmt.Errorf("failed to create new Client: %w", err)
+	}
+	defer zkClient.Close()
 
 	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "zookeeper_znode" {
+		if rs.Type != "zookeeper_znode" && rs.Type != "zookeeper_sequential_znode" {
 			continue
 		}
 


### PR DESCRIPTION
This makes the operator hold the connection to ZooKeeper in a pool of `client.Client`, indexed by their construction parameters.

The underlying ZooKeeper client is perfectly able to handle concurrent use, as well as automatic reconnection. So this approach ensures we keep around the minimum amount of connections necessary, and delegate to the underlying client the concurrency.

Additionally, this also stops the `resource.ParallelTest` provided by Terraform SDKv2, spawn 1 provider for each test execution. Instead, it shares the one instance.

This also solves the issue identified by @abarabash-sift in #49.